### PR TITLE
Add Link Contact Feature

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -48,4 +49,7 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    List<Person> getLinkedPersons(Person person);
+
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -85,4 +86,10 @@ public class LogicManager implements Logic {
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }
+
+    @Override
+    public List<Person> getLinkedPersons(Person person) {
+        return model.getLinkedPersons(person);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -39,7 +39,7 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        addressBookParser = new AddressBookParser();
+        addressBookParser = new AddressBookParser(model);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Links two contacts together (e.g. a student and a parent).
+ */
+public class LinkCommand extends Command {
+
+    public static final String COMMAND_WORD = "link";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links two contacts together by name and phone.\n"
+            + "Parameters: sn/STUDENT_NAME [sp/STUDENT_PHONE] pn/PARENT_NAME [pp/PARENT_PHONE]\n"
+            + "Example: " + COMMAND_WORD + " sn/John Tan sp/91234567 pn/Mrs Tan pp/92345678";
+
+    public static final String MESSAGE_LINK_SUCCESS = "Linked %1$s ↔ %2$s";
+    public static final String MESSAGE_DUPLICATE_LINK = "These contacts are already linked.";
+    public static final String MESSAGE_SAME_PERSON = "Cannot link a contact to itself.";
+    public static final String MESSAGE_NOT_FOUND = "One or both contacts could not be found.";
+
+    private final Person student;
+    private final Person parent;
+
+    /**
+     * Creates a LinkCommand with both contacts resolved.
+     */
+    public LinkCommand(Person student, Person parent) {
+        requireNonNull(student);
+        requireNonNull(parent);
+        this.student = student;
+        this.parent = parent;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (student.equals(parent)) {
+            throw new CommandException(MESSAGE_SAME_PERSON);
+        }
+
+        boolean success = model.link(student, parent);
+        if (!success) {
+            throw new CommandException(MESSAGE_DUPLICATE_LINK);
+        }
+
+        return new CommandResult(String.format(MESSAGE_LINK_SUCCESS,
+                Messages.format(student), Messages.format(parent)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof LinkCommand)) {
+            return false;
+        }
+        LinkCommand otherCommand = (LinkCommand) other;
+        return student.equals(otherCommand.student)
+                && parent.equals(otherCommand.parent);
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/UnlinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnlinkCommand.java
@@ -8,28 +8,29 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Links two contacts together (e.g. a student and a parent).
+ * Removes a link between two contacts (e.g. a student and a parent).
  */
-public class LinkCommand extends Command {
+public class UnlinkCommand extends Command {
 
-    public static final String COMMAND_WORD = "link";
+    public static final String COMMAND_WORD = "unlink";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links two contacts together by name and phone.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes the link between two contacts.\n"
             + "Parameters: sn/STUDENT_NAME [sp/STUDENT_PHONE] pn/PARENT_NAME [pp/PARENT_PHONE]\n"
             + "Example: " + COMMAND_WORD + " sn/John Tan sp/91234567 pn/Mrs Tan pp/92345678";
 
-    public static final String MESSAGE_LINK_SUCCESS = "Linked %1$s ↔ %2$s";
-    public static final String MESSAGE_DUPLICATE_LINK = "These contacts are already linked.";
-    public static final String MESSAGE_SAME_PERSON = "Cannot link a contact to itself.";
+    public static final String MESSAGE_SUCCESS = "Unlinked %1$s ↔ %2$s";
+    public static final String MESSAGE_NOT_LINKED = "These contacts are not currently linked.";
+    public static final String MESSAGE_SAME_PERSON = "Cannot unlink a contact from itself.";
     public static final String MESSAGE_NOT_FOUND = "One or both contacts could not be found.";
 
     private final Person student;
     private final Person parent;
 
     /**
-     * Creates a LinkCommand with both contacts resolved.
+     * Create an UnlinkCommand with both contacts resolved.
      */
-    public LinkCommand(Person student, Person parent) {
+    public UnlinkCommand(Person student, Person parent) {
         requireNonNull(student);
         requireNonNull(parent);
         this.student = student;
@@ -44,26 +45,21 @@ public class LinkCommand extends Command {
             throw new CommandException(MESSAGE_SAME_PERSON);
         }
 
-        boolean success = model.link(student, parent);
+        boolean success = model.unlink(student, parent);
         if (!success) {
-            throw new CommandException(MESSAGE_DUPLICATE_LINK);
+            throw new CommandException(MESSAGE_NOT_LINKED);
         }
 
-        return new CommandResult(String.format(MESSAGE_LINK_SUCCESS,
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
                 Messages.format(student), Messages.format(parent)));
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if (!(other instanceof LinkCommand)) {
-            return false;
-        }
-        LinkCommand otherCommand = (LinkCommand) other;
-        return student.equals(otherCommand.student)
-                && parent.equals(otherCommand.parent);
+        return other == this
+                || (other instanceof UnlinkCommand
+                && student.equals(((UnlinkCommand) other).student)
+                && parent.equals(((UnlinkCommand) other).parent));
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,8 +16,9 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.LinkCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UnlinkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 
@@ -86,6 +87,9 @@ public class AddressBookParser {
 
         case LinkCommand.COMMAND_WORD:
             return new LinkCommandParser(model).parse(arguments);
+
+        case UnlinkCommand.COMMAND_WORD:
+            return new UnlinkCommandParser(model).parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,7 +17,9 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.LinkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 
 /**
  * Parses user input.
@@ -29,6 +31,11 @@ public class AddressBookParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+    private final Model model;
+
+    public AddressBookParser(Model model) {
+        this.model = model;
+    }
 
     /**
      * Parses user input into command for execution.
@@ -76,6 +83,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case LinkCommand.COMMAND_WORD:
+            return new LinkCommandParser(model).parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,9 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_STUDENT_NAME = new Prefix("sn/");
+    public static final Prefix PREFIX_STUDENT_PHONE = new Prefix("sp/");
+    public static final Prefix PREFIX_PARENT_NAME = new Prefix("pn/");
+    public static final Prefix PREFIX_PARENT_PHONE = new Prefix("pp/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/LinkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LinkCommandParser.java
@@ -1,6 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PARENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PARENT_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_PHONE;
 
 import java.util.List;
 
@@ -13,14 +17,7 @@ import seedu.address.model.person.Person;
  * Parses input arguments and creates a new LinkCommand object.
  */
 public class LinkCommandParser implements Parser<LinkCommand> {
-
-    private static final Prefix PREFIX_STUDENT_NAME = new Prefix("sn/");
-    private static final Prefix PREFIX_STUDENT_PHONE = new Prefix("sp/");
-    private static final Prefix PREFIX_PARENT_NAME = new Prefix("pn/");
-    private static final Prefix PREFIX_PARENT_PHONE = new Prefix("pp/");
-
     private final Model model;
-
     /**
      * Model is injected here to resolve Person objects by name and phone.
      * This approach follows AB3 testability (dependency passed from LogicManager).

--- a/src/main/java/seedu/address/logic/parser/UnlinkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnlinkCommandParser.java
@@ -1,0 +1,72 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.UnlinkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Parses input arguments and creates a new UnlinkCommand object.
+ */
+public class UnlinkCommandParser implements Parser<UnlinkCommand> {
+
+    private static final Prefix PREFIX_STUDENT_NAME = new Prefix("sn/");
+    private static final Prefix PREFIX_STUDENT_PHONE = new Prefix("sp/");
+    private static final Prefix PREFIX_PARENT_NAME = new Prefix("pn/");
+    private static final Prefix PREFIX_PARENT_PHONE = new Prefix("pp/");
+
+    private final Model model;
+
+    public UnlinkCommandParser(Model model) {
+        this.model = model;
+    }
+
+    @Override
+    public UnlinkCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_NAME, PREFIX_STUDENT_PHONE,
+                        PREFIX_PARENT_NAME, PREFIX_PARENT_PHONE);
+
+        if (!argMultimap.getValue(PREFIX_STUDENT_NAME).isPresent()
+                || !argMultimap.getValue(PREFIX_PARENT_NAME).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnlinkCommand.MESSAGE_USAGE));
+        }
+
+        String studentName = argMultimap.getValue(PREFIX_STUDENT_NAME).get().trim();
+        String studentPhone = argMultimap.getValue(PREFIX_STUDENT_PHONE).orElse("").trim();
+        String parentName = argMultimap.getValue(PREFIX_PARENT_NAME).get().trim();
+        String parentPhone = argMultimap.getValue(PREFIX_PARENT_PHONE).orElse("").trim();
+
+        Person student = resolvePerson(studentName, studentPhone);
+        Person parent = resolvePerson(parentName, parentPhone);
+
+        if (student == null || parent == null) {
+            throw new ParseException(UnlinkCommand.MESSAGE_NOT_FOUND);
+        }
+
+        return new UnlinkCommand(student, parent);
+    }
+
+    /** Finds a unique Person by name and (optionally) phone number. */
+    private Person resolvePerson(String name, String phone) {
+        var allPersons = model.getFilteredPersonList();
+        var nameMatches = allPersons.stream()
+                .filter(p -> p.getName().fullName.equalsIgnoreCase(name))
+                .toList();
+
+        if (nameMatches.isEmpty()) {
+            return null;
+        }
+        if (nameMatches.size() == 1) {
+            return nameMatches.get(0);
+        }
+        if (!phone.isEmpty()) {
+            return nameMatches.stream()
+                    .filter(p -> p.getPhone().value.equals(phone))
+                    .findFirst().orElse(null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -84,4 +85,24 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    //=========== Relationship management =============================================================
+
+    /**
+     * Creates a bidirectional link between two persons.
+     * Returns true if link was added successfully, false if it already exists.
+     */
+    boolean link(Person a, Person b);
+
+    /**
+     * Removes a bidirectional link between two persons, if it exists.
+     * Returns true if link was removed, false otherwise.
+     */
+    boolean unlink(Person a, Person b);
+
+    /**
+     * Returns a list of persons linked to the given person.
+     */
+    List<Person> getLinkedPersons(Person person);
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,6 +14,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.util.RelationshipGraph;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +25,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final RelationshipGraph relationshipGraph = new RelationshipGraph();
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -143,6 +147,26 @@ public class ModelManager implements Model {
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredPersons.equals(otherModelManager.filteredPersons);
+    }
+
+    //=========== Relationship management =============================================================
+
+    @Override
+    public boolean link(Person a, Person b) {
+        requireAllNonNull(a, b);
+        return relationshipGraph.addLink(a, b);
+    }
+
+    @Override
+    public boolean unlink(Person a, Person b) {
+        requireAllNonNull(a, b);
+        return relationshipGraph.removeLink(a, b);
+    }
+
+    @Override
+    public List<Person> getLinkedPersons(Person person) {
+        requireNonNull(person);
+        return new ArrayList<>(relationshipGraph.getLinked(person));
     }
 
 }

--- a/src/main/java/seedu/address/model/util/RelationshipGraph.java
+++ b/src/main/java/seedu/address/model/util/RelationshipGraph.java
@@ -1,0 +1,63 @@
+package seedu.address.model.util;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import seedu.address.model.person.Person;
+
+/**
+ * Represents undirected relationships (links) between Person objects.
+ */
+public class RelationshipGraph {
+
+    private final Map<Person, Set<Person>> links = new HashMap<>();
+
+    /** Adds a bidirectional link between two persons. Returns true if successful, false if it already exists. */
+    public boolean addLink(Person a, Person b) {
+        if (a.equals(b)) {
+            return false; // no self link
+        }
+        links.putIfAbsent(a, new HashSet<>());
+        links.putIfAbsent(b, new HashSet<>());
+
+        boolean addedA = links.get(a).add(b);
+        boolean addedB = links.get(b).add(a);
+        return addedA || addedB;
+    }
+
+    /** Removes a bidirectional link between two persons. */
+    public boolean removeLink(Person a, Person b) {
+        boolean removed = false;
+        if (links.containsKey(a)) {
+            removed |= links.get(a).remove(b);
+            if (links.get(a).isEmpty()) {
+                links.remove(a);
+            }
+        }
+        if (links.containsKey(b)) {
+            removed |= links.get(b).remove(a);
+            if (links.get(b).isEmpty()) {
+                links.remove(b);
+            }
+        }
+        return removed;
+    }
+
+    /** Returns linked persons of the given person. */
+    public Set<Person> getLinked(Person person) {
+        return links.getOrDefault(person, new HashSet<>());
+    }
+
+    /** Cleans up all relationships involving this person (called when person is deleted). */
+    public void removeAll(Person person) {
+        if (!links.containsKey(person)) {
+            return;
+        }
+        for (Person p : new HashSet<>(links.get(person))) {
+            links.get(p).remove(person);
+        }
+        links.remove(person);
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -110,7 +110,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), logic);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,12 +1,14 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.logic.Logic;
 import seedu.address.model.person.Person;
 
 /**
@@ -16,15 +18,8 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
 
-    /**
-     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
-     * As a consequence, UI elements' variable names cannot be set to such keywords
-     * or an exception will be thrown by JavaFX during runtime.
-     *
-     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
-     */
-
     public final Person person;
+    private final Logic logic;
 
     @FXML
     private HBox cardPane;
@@ -40,20 +35,49 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+    @FXML
+    private Label linkedContacts;
 
     /**
-     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     * Creates a {@code PersonCard} with the given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex) {
+    public PersonCard(Person person, int displayedIndex, Logic logic) {
         super(FXML);
         this.person = person;
+        this.logic = logic;
+
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+
+        // show linked contacts if any exist
+        String linkedText = getLinkedText(person);
+        linkedContacts.setText(linkedText.isEmpty() ? "" : "Linked: " + linkedText);
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    /**
+     * Returns a comma-separated list of linked contact names, or an empty string if none.
+     */
+    private String getLinkedText(Person person) {
+        if (logic == null) {
+            return "";
+        }
+
+        var linkedList = logic.getLinkedPersons(person);
+        if (linkedList.isEmpty()) {
+            return "";
+        }
+
+        String joined = linkedList.stream()
+                .map(p -> p.getName().fullName)
+                .limit(3)
+                .collect(Collectors.joining(", "));
+        return linkedList.size() > 3 ? joined + "…" : joined;
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -8,6 +8,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.Logic;
 import seedu.address.model.person.Person;
 
 /**
@@ -17,14 +18,17 @@ public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
+    private final Logic logic;
+
     @FXML
     private ListView<Person> personListView;
 
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(ObservableList<Person> personList, Logic logic) {
         super(FXML);
+        this.logic = logic;
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
@@ -41,7 +45,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                setGraphic(new PersonCard(person, getIndex() + 1, logic).getRoot());
             }
         }
     }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -26,6 +26,7 @@
           </minWidth>
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="linkedContacts" style="-fx-font-size: 11px; -fx-text-fill: white;" />
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -162,6 +162,17 @@ public class AddCommandTest {
         public ObservableList<Person> getLinkedPersons(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean link(Person a, Person b) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean unlink(Person a, Person b) {
+            throw new AssertionError("This method should not be called.");
+        }
+
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -157,6 +157,11 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public ObservableList<Person> getLinkedPersons(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**
@@ -200,5 +205,4 @@ public class AddCommandTest {
             return new AddressBook();
         }
     }
-
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -31,7 +32,8 @@ import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 
-    private final AddressBookParser parser = new AddressBookParser();
+    private Model model;
+    private final AddressBookParser parser = new AddressBookParser(model);
 
     @Test
     public void parseCommand_add() throws Exception {


### PR DESCRIPTION
What I have done:
Command parsing: link sn/... pn/... works correctly
Model integration: ModelManager.link() + RelationshipGraph fully functional
Command execution: Prevents self/duplicate links; shows success message
UI display: Linked names shown under each contact (white text)
Unlink command: unlink sn/... pn/... works correctly

What I have not done: 
Persistence: Currently in-memory (resets on restart — fine for MVP)
Delete cleanup: Links remain in graph if a contact is deleted — next iteration