### PR TITLE
Add sequence diagram for filter by tag command

### DIFF
--- a/docs/diagrams/FilterByTagSequenceDiagram.puml
+++ b/docs/diagrams/FilterByTagSequenceDiagram.puml
@@ -1,0 +1,68 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":FilterTagCommandParser" as FilterTagCommandParser LOGIC_COLOR
+participant "f:FilterTagCommand" as FilterTagCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("filter math j2")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("filter math j2")
+activate AddressBookParser
+
+create FilterTagCommandParser
+AddressBookParser -> FilterTagCommandParser
+activate FilterTagCommandParser
+
+FilterTagCommandParser --> AddressBookParser
+deactivate FilterTagCommandParser
+
+AddressBookParser -> FilterTagCommandParser : parse("math j2")
+activate FilterTagCommandParser
+
+create FilterTagCommand
+FilterTagCommandParser -> FilterTagCommand : «constructor» FilterTagCommand(TagContainsKeywordsPredicate)
+activate FilterTagCommand
+
+FilterTagCommand --> FilterTagCommandParser :
+deactivate FilterTagCommand
+
+FilterTagCommandParser --> AddressBookParser : f
+deactivate FilterTagCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+FilterTagCommandParser -[hidden]-> AddressBookParser
+destroy FilterTagCommandParser
+
+AddressBookParser --> LogicManager : f
+deactivate AddressBookParser
+
+LogicManager -> FilterTagCommand : execute(m)
+activate FilterTagCommand
+
+FilterTagCommand -> Model : updateFilteredPersonList(predicate)
+activate Model
+Model --> FilterTagCommand
+deactivate Model
+
+create CommandResult
+FilterTagCommand -> CommandResult
+activate CommandResult
+CommandResult --> FilterTagCommand
+deactivate CommandResult
+
+FilterTagCommand --> LogicManager : r
+deactivate FilterTagCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
Added FilterByTagSequenceDiagram.puml under diagrams.

This diagram documents the end-to-end flow for the filter feature, showing how LogicManager, AddressBookParser, FilterTagCommandParser, FilterTagCommand, and Model interact to update the filtered person list.

Diagram type: Sequence Diagram
Scenario: Execution of filter <tags> command (e.g., filter math j2)
Highlights:
Starts from the external call to LogicManager#execute()
Shows parsing flow through AddressBookParser and FilterTagCommandParser
Includes creation of FilterTagCommand and CommandResult
Illustrates Model#updateFilteredPersonList(predicate) invocation
Uses style.puml for consistent logic/model coloring and formatting

Successfully rendered without warnings in PlantUML
